### PR TITLE
readme.md: correct package listing for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ OSX comes with Python preinstalled. To install the required extensions, issue th
 
 *Tested on Ubuntu 13.04 Raring Ringtail*
 
-    sudo apt-get install python-pycryptopp python-requests
+    sudo apt-get install python-crypto python-requests
 
 #### Windows
 


### PR DESCRIPTION
On Debian and Ubuntu, `python-crypto` is required, not `python-pycryptopp`.

I suspect the README depended on a pre-existing install of `python-crypto`.
